### PR TITLE
getinput: cache puzzle input

### DIFF
--- a/getinput/getinput.go
+++ b/getinput/getinput.go
@@ -1,14 +1,19 @@
 package getinput
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
-	"net/http"
-	"strings"
 	"log"
+	"net/http"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
 )
 
-func Get(year int, day int, sessionKey string) ([]string, error) {
+func get(year int, day int, sessionKey string) ([]byte, error) {
 	client := &http.Client{}
 	url := fmt.Sprintf("http://adventofcode.com/%d/day/%d/input", year, day)
 	log.Printf("Fetching input: %s", url)
@@ -31,8 +36,45 @@ func Get(year int, day int, sessionKey string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	return contents, nil
+}
 
-	ret := strings.Split(string(contents), "\n")
+func Get(year int, day int, sessionKey string) ([]string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("could not get current user: %v", err)
+	}
+	cacheFilename := filepath.Join(os.TempDir(), "advent", u.Username, strconv.Itoa(year), strconv.Itoa(day))
+
+	var b []byte
+	if _, err := os.Stat(cacheFilename); err != nil {
+		// ensure read and write for current user
+		if sessionKey == "" {
+			return nil, errors.New("no session key provided")
+		}
+		err := os.MkdirAll(filepath.Dir(cacheFilename), os.ModePerm)
+		if err != nil {
+			return nil, fmt.Errorf("could not create advent cache dir: %v", err)
+		}
+
+		b, err = get(year, day, sessionKey)
+		if err != nil {
+			return nil, fmt.Errorf("error fetching puzzle: %v", err)
+		}
+		// give read-write to current user, read to others
+		if err := ioutil.WriteFile(cacheFilename, b, 0644); err != nil {
+			return nil, fmt.Errorf("error saving puzzle: %v", err)
+		}
+
+	} else {
+		var err error
+		b, err = ioutil.ReadFile(cacheFilename)
+		if err != nil {
+			return nil, fmt.Errorf("error reading cache: %v", err)
+		}
+	}
+
+	ret := strings.Split(string(b), "\n")
 
 	if len(ret[len(ret)-1]) == 0 {
 		// Last one is empty, discard


### PR DESCRIPTION
Add cache to puzzle input by saving body in temp directory.

Also return error if no session key is provided and there is no cached body.